### PR TITLE
Add JUnit test for AddCommand class for invalid date format

### DIFF
--- a/src/test/java/seedu/duke/command/AddCommandTest.java
+++ b/src/test/java/seedu/duke/command/AddCommandTest.java
@@ -13,26 +13,28 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AddCommandTest {
     @Test
-    public void execute_EmptyDate_ExpectedException () {
+    public void execute_EmptyDate_ExpectedException() {
         TransactionList transactions = new TransactionList();
         Ui ui = new Ui();
         Storage storage = new Storage();
         AddCommand addCommand = new AddCommand("t/income c/bonus a/-1 d/ i/thank_you_boss");
 
-        assertThrows(AddTransactionInvalidDateException.class,
-                () -> addCommand.execute(transactions, ui, storage)
+        assertThrows(
+            AddTransactionInvalidDateException.class,
+            () -> addCommand.execute(transactions, ui, storage)
         );
     }
 
     @Test
-    public void execute_InvalidDateFormat_ExpectedException () {
+    public void execute_InvalidDateFormat_ExpectedException() {
         TransactionList transactions = new TransactionList();
         Ui ui = new Ui();
         Storage storage = new Storage();
         AddCommand addCommand = new AddCommand("t/income c/bonus a/-1 d/2020-01-01 i/thank_you_boss");
 
-        assertThrows(AddTransactionInvalidDateException.class,
-                () -> addCommand.execute(transactions, ui, storage)
+        assertThrows(
+            AddTransactionInvalidDateException.class,
+            () -> addCommand.execute(transactions, ui, storage)
         );
     }
 

--- a/src/test/java/seedu/duke/command/AddCommandTest.java
+++ b/src/test/java/seedu/duke/command/AddCommandTest.java
@@ -1,12 +1,40 @@
 package seedu.duke.command;
 
 import org.junit.jupiter.api.Test;
+import seedu.duke.Storage;
+import seedu.duke.Ui;
+import seedu.duke.data.TransactionList;
+import seedu.duke.exception.AddTransactionInvalidDateException;
 
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AddCommandTest {
+    @Test
+    public void execute_EmptyDate_ExpectedException () {
+        TransactionList transactions = new TransactionList();
+        Ui ui = new Ui();
+        Storage storage = new Storage();
+        AddCommand addCommand = new AddCommand("t/income c/bonus a/-1 d/ i/thank_you_boss");
+
+        assertThrows(AddTransactionInvalidDateException.class,
+                () -> addCommand.execute(transactions, ui, storage)
+        );
+    }
+
+    @Test
+    public void execute_InvalidDateFormat_ExpectedException () {
+        TransactionList transactions = new TransactionList();
+        Ui ui = new Ui();
+        Storage storage = new Storage();
+        AddCommand addCommand = new AddCommand("t/income c/bonus a/-1 d/2020-01-01 i/thank_you_boss");
+
+        assertThrows(AddTransactionInvalidDateException.class,
+                () -> addCommand.execute(transactions, ui, storage)
+        );
+    }
 
     @Test
     public void containNumeric_IfContainsNumeric_ReturnTrue() {


### PR DESCRIPTION
To ensure that the empty date and not-supported date format will throw a correct AddTransactionInvalidDateException exception.