### PR TITLE
Move help information to Help Messages Enum class and sync descriptions to be in-line with UG

### DIFF
--- a/src/main/java/seedu/duke/command/AddCommand.java
+++ b/src/main/java/seedu/duke/command/AddCommand.java
@@ -28,9 +28,15 @@ import static seedu.duke.command.CommandTag.COMMAND_TAG_TRANSACTION_DESCRIPTION;
 import static seedu.duke.command.CommandTag.COMMAND_TAG_TRANSACTION_TYPE;
 
 import static seedu.duke.common.Constants.MAX_TRANSACTIONS_COUNT;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_TYPE;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_CATEGORY;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_AMOUNT;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_DESCRIPTION;
+import static seedu.duke.common.HelpMessages.COMMAND_DESCRIPTION_ADD;
+import static seedu.duke.common.HelpMessages.COMMAND_USAGE_ADD;
+import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
 import static seedu.duke.common.InfoMessages.INFO_ADD_EXPENSE;
 import static seedu.duke.common.InfoMessages.INFO_ADD_INCOME;
-import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
 
 /**
  * Represents an add command object that will execute the operations for Add command.
@@ -39,24 +45,13 @@ public class AddCommand extends Command {
     //@@author chinhan99
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "ADD";
-
-    // The description for the usage of command
-    public static final String COMMAND_DESCRIPTION = "To add a new transaction entry, which could be "
-            + "either an \"income\" or an \"expense\" into the transaction list.";
-    // The guiding information for the usage of command
-    public static final String COMMAND_USAGE = "Usage: add t/TYPE c/CATEGORY a/AMOUNT d/DATE i/DESCRIPTION";
     // The formatting information for the parameters used by the command
-    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:"
-            + LINE_SEPARATOR
-            + "TYPE: The type of transaction. Only \"income\" or \"expense\" is accepted." + LINE_SEPARATOR
-            + "CATEGORY: A category for the transaction. Only string containing alphabets is accepted."
-            + LINE_SEPARATOR
-            + "AMOUNT: Value of the transaction in numerical form. Only integer within 0 and 10000000 is accepted."
-            + LINE_SEPARATOR + "DATE: Date of the transaction. The format must be in \"yyyyMMdd\"." + LINE_SEPARATOR
-            + "DESCRIPTION: More information regarding the transaction, written without any space.";
+    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:" + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_TYPE + LINE_SEPARATOR + COMMAND_PARAMETERS_CATEGORY + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_AMOUNT + LINE_SEPARATOR + COMMAND_PARAMETERS_DESCRIPTION;
     // Basic help description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR
-            + COMMAND_DESCRIPTION + LINE_SEPARATOR + COMMAND_USAGE + LINE_SEPARATOR;
+            + COMMAND_DESCRIPTION_ADD + LINE_SEPARATOR + COMMAND_USAGE_ADD + LINE_SEPARATOR;
     // Detailed help description
     public static final String COMMAND_DETAILED_HELP = COMMAND_HELP + COMMAND_PARAMETERS_INFO + LINE_SEPARATOR;
 

--- a/src/main/java/seedu/duke/command/BudgetCommand.java
+++ b/src/main/java/seedu/duke/command/BudgetCommand.java
@@ -11,6 +11,9 @@ import seedu.duke.exception.StorageWriteErrorException;
 import java.io.IOException;
 
 import static seedu.duke.command.CommandTag.COMMAND_TAG_BUDGET_AMOUNT;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_BUDGET;
+import static seedu.duke.common.HelpMessages.COMMAND_DESCRIPTION_BUDGET;
+import static seedu.duke.common.HelpMessages.COMMAND_USAGE_BUDGET;
 import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
 
 /**
@@ -19,18 +22,12 @@ import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
 public class BudgetCommand extends Command {
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "BUDGET";
-    // The description for the usage of command
-    public static final String COMMAND_DESCRIPTION = "To set the amount of monthly budget.";
-    // The guiding information for the usage of command
-    public static final String COMMAND_USAGE = "Usage: budget b/BUDGET";
     // The formatting information for the parameters used by the command
-    public static final String COMMAND_PARAMETERS_INFO = "Parameters information: "
-            + LINE_SEPARATOR
-            + "BUDGET - Amount of monthly budget set.";
-
+    public static final String COMMAND_PARAMETERS_INFO = "Parameters information: " + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_BUDGET;
     // Basic budget description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR
-            + COMMAND_DESCRIPTION + LINE_SEPARATOR + COMMAND_USAGE + LINE_SEPARATOR;
+            + COMMAND_DESCRIPTION_BUDGET + LINE_SEPARATOR + COMMAND_USAGE_BUDGET + LINE_SEPARATOR;
     // Detailed budget description
     public static final String COMMAND_DETAILED_HELP = COMMAND_HELP + COMMAND_PARAMETERS_INFO
             + LINE_SEPARATOR;

--- a/src/main/java/seedu/duke/command/BudgetCommand.java
+++ b/src/main/java/seedu/duke/command/BudgetCommand.java
@@ -23,7 +23,7 @@ public class BudgetCommand extends Command {
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "BUDGET";
     // The formatting information for the parameters used by the command
-    public static final String COMMAND_PARAMETERS_INFO = "Parameters information: " + LINE_SEPARATOR
+    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:" + LINE_SEPARATOR
             + COMMAND_PARAMETERS_BUDGET;
     // Basic budget description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR

--- a/src/main/java/seedu/duke/command/ByeCommand.java
+++ b/src/main/java/seedu/duke/command/ByeCommand.java
@@ -5,6 +5,8 @@ import seedu.duke.Storage;
 import seedu.duke.Ui;
 import seedu.duke.data.TransactionList;
 
+import static seedu.duke.common.HelpMessages.COMMAND_DESCRIPTION_BYE;
+import static seedu.duke.common.HelpMessages.COMMAND_USAGE_BYE;
 import static seedu.duke.common.InfoMessages.INFO_EXIT;
 import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
 
@@ -15,16 +17,11 @@ public class ByeCommand extends Command {
     //@@author paullowse
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "BYE";
-    // The description for the usage of command
-    public static final String COMMAND_DESCRIPTION = "To exit the application.";
-    // The guiding information for the usage of command
-    public static final String COMMAND_USAGE = "Usage: bye";
     // The formatting information for the parameters used by the command
     public static final String COMMAND_PARAMETERS_INFO = "Parameters information: -NIL-";
-
     // Basic help description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR
-            + COMMAND_DESCRIPTION + LINE_SEPARATOR + COMMAND_USAGE + LINE_SEPARATOR;
+            + COMMAND_DESCRIPTION_BYE + LINE_SEPARATOR + COMMAND_USAGE_BYE + LINE_SEPARATOR;
     // Detailed help description
     public static final String COMMAND_DETAILED_HELP = COMMAND_HELP + COMMAND_PARAMETERS_INFO
             + LINE_SEPARATOR;

--- a/src/main/java/seedu/duke/command/DeleteCommand.java
+++ b/src/main/java/seedu/duke/command/DeleteCommand.java
@@ -16,6 +16,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static seedu.duke.command.CommandTag.COMMAND_TAG_GLOBAL_ENTRY_NUMBER;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_ENTRY;
+import static seedu.duke.common.HelpMessages.COMMAND_DESCRIPTION_DELETE;
+import static seedu.duke.common.HelpMessages.COMMAND_USAGE_DELETE;
 import static seedu.duke.common.InfoMessages.INFO_DELETE;
 import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
 
@@ -26,19 +29,12 @@ public class DeleteCommand extends Command {
     //@@author brian-vb
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "DELETE";
-    // The description for the usage of command
-    public static final String COMMAND_DESCRIPTION = "To delete a specific entry in the list of transactions.";
-    // The guiding information for the usage of command
-    public static final String COMMAND_USAGE = "Usage: delete e/ENTRY";
     // The formatting information for the parameters used by the command
-    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:"
-            + LINE_SEPARATOR
-            + "ENTRY: The entry number of the transaction. "
-            + "Type \"list\" to list all the entry numbers of transaction.";
-
+    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:" + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_ENTRY;
     // Basic help description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR
-            + COMMAND_DESCRIPTION + LINE_SEPARATOR + COMMAND_USAGE + LINE_SEPARATOR;
+            + COMMAND_DESCRIPTION_DELETE + LINE_SEPARATOR + COMMAND_USAGE_DELETE + LINE_SEPARATOR;
     // Detailed help description
     public static final String COMMAND_DETAILED_HELP = COMMAND_HELP + COMMAND_PARAMETERS_INFO
             + LINE_SEPARATOR;

--- a/src/main/java/seedu/duke/command/EditCommand.java
+++ b/src/main/java/seedu/duke/command/EditCommand.java
@@ -26,6 +26,14 @@ import static seedu.duke.command.CommandTag.COMMAND_TAG_TRANSACTION_CATEGORY;
 import static seedu.duke.command.CommandTag.COMMAND_TAG_TRANSACTION_DATE;
 import static seedu.duke.command.CommandTag.COMMAND_TAG_TRANSACTION_AMOUNT;
 import static seedu.duke.command.CommandTag.COMMAND_TAG_TRANSACTION_DESCRIPTION;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_ENTRY;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_TYPE;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_CATEGORY;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_AMOUNT;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_DATE;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_DESCRIPTION;
+import static seedu.duke.common.HelpMessages.COMMAND_DESCRIPTION_EDIT;
+import static seedu.duke.common.HelpMessages.COMMAND_USAGE_EDIT;
 import static seedu.duke.common.InfoMessages.INFO_EDIT_EXPENSE;
 import static seedu.duke.common.InfoMessages.INFO_EDIT_INCOME;
 import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
@@ -37,31 +45,15 @@ public class EditCommand extends Command {
     //@@author brian-vb
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "EDIT";
-    // The description for the usage of command
-    public static final String COMMAND_DESCRIPTION = "To edit a specific entry in the list of transactions.";
-    // The guiding information for the usage of command
-    public static final String COMMAND_USAGE = "Usage: "
-            + "edit e/ENTRY [t/TYPE] [c/CATEGORY] [a/AMOUNT] [d/DATE] [i/DESCRIPTION]";
     // The formatting information for the parameters used by the command
-    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:"
-            + LINE_SEPARATOR
-            + "ENTRY: The entry number of the transaction. "
-            + "Type \"list\" to list all the entry numbers of transaction."
-            + LINE_SEPARATOR
-            + "(Optional) TYPE: The type of transaction. Only \"income\" or \"expense\" is accepted."
-            + LINE_SEPARATOR
-            + "(Optional) CATEGORY: A category for the transaction. Only string containing alphabets is accepted."
-            + LINE_SEPARATOR
-            + "(Optional) AMOUNT: Value of the transaction in numerical form. "
-            + "Only integer within 0 and 10000000 is accepted."
-            + LINE_SEPARATOR
-            + "(Optional) DATE: Date of the transaction. The format must be in \"yyyyMMdd\"."
-            + LINE_SEPARATOR
-            + "(Optional) DESCRIPTION: More information regarding the transaction, written without any space.";
-
+    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:" + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_ENTRY + LINE_SEPARATOR + COMMAND_PARAMETERS_TYPE + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_CATEGORY + LINE_SEPARATOR + COMMAND_PARAMETERS_AMOUNT + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_AMOUNT + LINE_SEPARATOR + COMMAND_PARAMETERS_DATE + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_DESCRIPTION;
     // Basic help description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR
-            + COMMAND_DESCRIPTION + LINE_SEPARATOR + COMMAND_USAGE + LINE_SEPARATOR;
+            + COMMAND_DESCRIPTION_EDIT + LINE_SEPARATOR + COMMAND_USAGE_EDIT + LINE_SEPARATOR;
     // Detailed help description
     public static final String COMMAND_DETAILED_HELP = COMMAND_HELP + COMMAND_PARAMETERS_INFO
             + LINE_SEPARATOR;

--- a/src/main/java/seedu/duke/command/FindCommand.java
+++ b/src/main/java/seedu/duke/command/FindCommand.java
@@ -7,6 +7,9 @@ import seedu.duke.data.TransactionList;
 import seedu.duke.exception.FindTransactionMissingKeywordsException;
 import seedu.duke.exception.MoolahException;
 
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_KEYWORDS;
+import static seedu.duke.common.HelpMessages.COMMAND_DESCRIPTION_FIND;
+import static seedu.duke.common.HelpMessages.COMMAND_USAGE_FIND;
 import static seedu.duke.common.InfoMessages.INFO_LIST_FILTERED;
 import static seedu.duke.common.InfoMessages.INFO_LIST_UNFILTERED;
 import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
@@ -19,20 +22,12 @@ public class FindCommand extends Command {
     //@@author chydarren
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "FIND";
-    // The description for the usage of command
-    public static final String COMMAND_DESCRIPTION = "To find specific transaction(s) based "
-            + "on any keywords inputted by the user.";
-    // The guiding information for the usage of command
-    public static final String COMMAND_USAGE = "Usage: find KEYWORDS";
     // The formatting information for the parameters used by the command
-    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:"
-            + LINE_SEPARATOR
-            + "KEYWORDS: Any partial or full keyword(s) that matches the details of the transaction, "
-            + "such as type, category, amount, date or description.";
-
+    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:" + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_KEYWORDS;
     // Basic help description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR
-            + COMMAND_DESCRIPTION + LINE_SEPARATOR + COMMAND_USAGE + LINE_SEPARATOR;
+            + COMMAND_DESCRIPTION_FIND + LINE_SEPARATOR + COMMAND_USAGE_FIND + LINE_SEPARATOR;
     // Detailed help description
     public static final String COMMAND_DETAILED_HELP = COMMAND_HELP + COMMAND_PARAMETERS_INFO
             + LINE_SEPARATOR;

--- a/src/main/java/seedu/duke/command/HelpCommand.java
+++ b/src/main/java/seedu/duke/command/HelpCommand.java
@@ -6,6 +6,9 @@ import seedu.duke.Ui;
 import seedu.duke.data.TransactionList;
 
 import static seedu.duke.command.CommandTag.COMMAND_TAG_HELP_OPTION;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_DETAILED;
+import static seedu.duke.common.HelpMessages.COMMAND_DESCRIPTION_HELP;
+import static seedu.duke.common.HelpMessages.COMMAND_USAGE_HELP;
 import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
 
 
@@ -16,21 +19,12 @@ public class HelpCommand extends Command {
     //@@author wcwy
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "HELP";
-    // The description for the usage of command
-    public static final String COMMAND_DESCRIPTION = "To display a list of available commands "
-            + "with their respective expected parameters."
-            + LINE_SEPARATOR
-            + "Type \"help o/detailed\" for a detailed version of all parameters used.";
-    // The guiding information for the usage of command
-    public static final String COMMAND_USAGE = "Usage: help [o/detailed]";
     // The formatting information for the parameters used by the command
-    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:"
-            + LINE_SEPARATOR
-            + "(Optional) o/detailed - Detailed version of guide.";
-
+    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:" + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_DETAILED;
     // Basic help description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR
-            + COMMAND_DESCRIPTION + LINE_SEPARATOR + COMMAND_USAGE + LINE_SEPARATOR;
+            + COMMAND_DESCRIPTION_HELP + LINE_SEPARATOR + COMMAND_USAGE_HELP + LINE_SEPARATOR;
     // Detailed help description
     public static final String COMMAND_DETAILED_HELP = COMMAND_HELP + COMMAND_PARAMETERS_INFO + LINE_SEPARATOR;
 

--- a/src/main/java/seedu/duke/command/ListCommand.java
+++ b/src/main/java/seedu/duke/command/ListCommand.java
@@ -21,6 +21,15 @@ import static seedu.duke.command.CommandTag.COMMAND_TAG_GLOBAL_YEAR;
 import static seedu.duke.command.CommandTag.COMMAND_TAG_GLOBAL_NUMBER;
 import static seedu.duke.command.CommandTag.COMMAND_TAG_GLOBAL_PERIOD;
 
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_TYPE;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_CATEGORY;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_DATE;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_MONTH;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_YEAR;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_PERIOD;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_NUMBER;
+import static seedu.duke.common.HelpMessages.COMMAND_DESCRIPTION_LIST;
+import static seedu.duke.common.HelpMessages.COMMAND_USAGE_LIST;
 import static seedu.duke.common.InfoMessages.INFO_LIST;
 import static seedu.duke.common.InfoMessages.INFO_LIST_EMPTY;
 import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
@@ -32,39 +41,15 @@ public class ListCommand extends ListAndStatsCommand {
     //@@author chydarren
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "LIST";
-    // The description for the usage of command
-    public static final String COMMAND_DESCRIPTION = "To list all or some transactions based on selection."
-            + " Tags will be joined in the filter based on the 'AND' operation.";
-    // The guiding information for the usage of command
-    public static final String COMMAND_USAGE = "Usage: list [t/TYPE] [c/CATEGORY] [d/DATE] [m/MONTH] [y/YEAR] "
-            + "[p/PERIOD] [n/NUMBER]";
     // The formatting information for the parameters used by the command
-    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:"
-            + LINE_SEPARATOR
-            + "(Optional) TYPE - The type of transaction. Only \"income\" or \"expense\" is accepted."
-            + LINE_SEPARATOR
-            + "(Optional) CATEGORY: A category for the transaction. Only string containing alphabets is accepted."
-            + LINE_SEPARATOR
-            + "(Optional) DATE: Date of the transaction. The format must be in \"yyyyMMdd\"."
-            + LINE_SEPARATOR
-            + "(Optional) MONTH: Month of the transaction. Only integers within 1 to 12 are accepted. Note that "
-            + "month must be accompanied by a year. This tag cannot be used together with [p/PERIOD] or [n/NUMBER] "
-            + "tags."
-            + LINE_SEPARATOR
-            + "(Optional) YEAR: Year of the transaction. Only integers from 1000 onwards are accepted. "
-            + "This tag cannot be used together with [p/PERIOD] or [n/NUMBER] tags."
-            + LINE_SEPARATOR
-            + "(Optional) PERIOD: Period of the transaction. Only \"weeks\" or \"months\" is accepted. Note that "
-            + "period must be accompanied by a number to backdate from. This tag cannot be used together with "
-            + "[m/MONTH] or [y/YEAR] tags."
-            + LINE_SEPARATOR
-            + "(Optional) NUMBER: Last number of weeks or months. Only positive integers are accepted. Note that "
-            + "number must be accompanied by a period that represents weeks or months. This tag cannot be used "
-            + "together with [m/MONTH] or [y/YEAR] tags.";
-
+    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:" + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_TYPE + LINE_SEPARATOR + COMMAND_PARAMETERS_CATEGORY + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_DATE + LINE_SEPARATOR + COMMAND_PARAMETERS_MONTH + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_YEAR + LINE_SEPARATOR + COMMAND_PARAMETERS_PERIOD + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_NUMBER;
     // Basic help description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR
-            + COMMAND_DESCRIPTION + LINE_SEPARATOR + COMMAND_USAGE + LINE_SEPARATOR;
+            + COMMAND_DESCRIPTION_LIST + LINE_SEPARATOR + COMMAND_USAGE_LIST + LINE_SEPARATOR;
     // Detailed help description
     public static final String COMMAND_DETAILED_HELP = COMMAND_HELP + COMMAND_PARAMETERS_INFO + LINE_SEPARATOR;
 

--- a/src/main/java/seedu/duke/command/PurgeCommand.java
+++ b/src/main/java/seedu/duke/command/PurgeCommand.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static seedu.duke.common.HelpMessages.COMMAND_DESCRIPTION_PURGE;
+import static seedu.duke.common.HelpMessages.COMMAND_USAGE_PURGE;
 import static seedu.duke.common.InfoMessages.INFO_PURGE;
 import static seedu.duke.common.InfoMessages.INFO_PURGE_ABORT;
 import static seedu.duke.common.InfoMessages.INFO_PURGE_EMPTY;
@@ -24,17 +26,11 @@ public class PurgeCommand extends Command {
     //@@author brian-vb
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "PURGE";
-    // The description for the usage of command
-    public static final String COMMAND_DESCRIPTION = "To purge a all entries in the list of transactions.";
-    // The guiding information for the usage of command
-    public static final String COMMAND_USAGE = "Usage: purge";
     // The formatting information for the parameters used by the command
     public static final String COMMAND_PARAMETERS_INFO = "Parameters information:  -NIL-";
-
     // Basic help description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR
-            + COMMAND_DESCRIPTION + LINE_SEPARATOR
-            + COMMAND_USAGE + LINE_SEPARATOR;
+            + COMMAND_DESCRIPTION_PURGE + LINE_SEPARATOR + COMMAND_USAGE_PURGE + LINE_SEPARATOR;
     // Detailed help description
     public static final String COMMAND_DETAILED_HELP = COMMAND_HELP + COMMAND_PARAMETERS_INFO
             + LINE_SEPARATOR;

--- a/src/main/java/seedu/duke/command/StatsCommand.java
+++ b/src/main/java/seedu/duke/command/StatsCommand.java
@@ -20,6 +20,13 @@ import static seedu.duke.command.CommandTag.COMMAND_TAG_GLOBAL_NUMBER;
 import static seedu.duke.command.CommandTag.COMMAND_TAG_GLOBAL_PERIOD;
 import static seedu.duke.command.CommandTag.COMMAND_TAG_GLOBAL_YEAR;
 import static seedu.duke.command.CommandTag.COMMAND_TAG_STATS_TYPE;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_STATS_TYPE;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_MONTH;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_YEAR;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_PERIOD;
+import static seedu.duke.common.HelpMessages.COMMAND_PARAMETERS_NUMBER;
+import static seedu.duke.common.HelpMessages.COMMAND_DESCRIPTION_STATS;
+import static seedu.duke.common.HelpMessages.COMMAND_USAGE_STATS;
 import static seedu.duke.common.InfoMessages.COLON_SPACE;
 import static seedu.duke.common.InfoMessages.DOLLAR_SIGN;
 import static seedu.duke.common.InfoMessages.INFO_EXPENSE;
@@ -38,35 +45,14 @@ public class StatsCommand extends ListAndStatsCommand {
     //@@author paullowse
     // The command word used to trigger the execution of Moolah Manager's operations
     public static final String COMMAND_WORD = "STATS";
-    // The description for the usage of command
-    public static final String COMMAND_DESCRIPTION = "To get statistics of the transactions such"
-            + " as the total savings for each category, summary of expenditure over a time period.";
-    // The guiding information for the usage of command
-    public static final String COMMAND_USAGE = "Usage: stats s/STATS_TYPE [m/MONTH] [y/YEAR] [p/PERIOD] [n/NUMBER]";
     // The formatting information for the parameters used by the command
-    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:"
-            + LINE_SEPARATOR
-            + "STATISTICS_TYPE: The type of statistics to be generated. Only \"categorical_savings\", "
-            + "\"monthly_expenditure\" or \"time_insights\" is accepted."
-            + LINE_SEPARATOR
-            + "(Optional) MONTH: Month of the transaction. Only integers within 1 to 12 are accepted. Note that "
-            + "month must be accompanied by a year. This tag cannot be used together with [p/PERIOD] or [n/NUMBER] "
-            + "tags."
-            + LINE_SEPARATOR
-            + "(Optional) YEAR: Year of the transaction. Only integers from 1000 onwards are accepted."
-            + "This tag cannot be used together with [p/PERIOD] or [n/NUMBER] tags."
-            + LINE_SEPARATOR
-            + "(Optional) PERIOD: Period of the transaction. Only \"weeks\" or \"months\" is accepted. Note that "
-            + "period must be accompanied by a number to backdate from. This tag cannot be used together with "
-            + "[m/MONTH] or [y/YEAR] tags."
-            + LINE_SEPARATOR
-            + "(Optional) NUMBER: Last number of weeks or months. Only positive integers are accepted. Note that"
-            + "number must be accompanied by a period that represents weeks or months. This tag cannot be used "
-            + "together with [m/MONTH] or [y/YEAR] tags.";
-
+    public static final String COMMAND_PARAMETERS_INFO = "Parameters information:" + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_STATS_TYPE + LINE_SEPARATOR + COMMAND_PARAMETERS_MONTH + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_YEAR + LINE_SEPARATOR + COMMAND_PARAMETERS_PERIOD + LINE_SEPARATOR
+            + COMMAND_PARAMETERS_NUMBER;
     // Basic help description
     public static final String COMMAND_HELP = "Command Word: " + COMMAND_WORD + LINE_SEPARATOR
-            + COMMAND_DESCRIPTION + LINE_SEPARATOR + COMMAND_USAGE + LINE_SEPARATOR;
+            + COMMAND_DESCRIPTION_STATS + LINE_SEPARATOR + COMMAND_USAGE_STATS + LINE_SEPARATOR;
     // Detailed help description
     public static final String COMMAND_DETAILED_HELP = COMMAND_HELP + COMMAND_PARAMETERS_INFO
             + LINE_SEPARATOR;

--- a/src/main/java/seedu/duke/common/HelpMessages.java
+++ b/src/main/java/seedu/duke/common/HelpMessages.java
@@ -19,7 +19,7 @@ public enum HelpMessages {
             + "transactions retrieved from the records must match all the filter tags that have been specified in "
             + "order to be recognized as a valid record. The m/MONTH and y/YEAR tags should not be used together "
             + "with p/PERIOD and n/NUMBER tags."),
-    COMMAND_DESCRIPTION_PURGE("Delete all transaction entries from the list of transactions."),
+    COMMAND_DESCRIPTION_PURGE("Delete all transaction entries from the list of transactions. User must enter 'Y' to confirm the purge."),
     COMMAND_DESCRIPTION_STATS("View financial insights such as categorical savings and periodic expenditure based on "
             + "the transaction entries in the application. The m/MONTH and y/YEAR tags should not be used together "
             + "with p/PERIOD and n/NUMBER tags."),

--- a/src/main/java/seedu/duke/common/HelpMessages.java
+++ b/src/main/java/seedu/duke/common/HelpMessages.java
@@ -1,0 +1,89 @@
+package seedu.duke.common;
+
+/**
+ * Provides enum variables for storing help messages across all command classes.
+ */
+public enum HelpMessages {
+    // The description for the usage of command
+    COMMAND_DESCRIPTION_ADD("Add a new transaction entry, which could be either an \"expense\" or \"income\" into "
+            + "the transactions list."),
+    COMMAND_DESCRIPTION_BUDGET("Set the amount for monthly budget, with a value from 1 to 10^13 (Ten Trillion)."),
+    COMMAND_DESCRIPTION_BYE("Exit the application."),
+    COMMAND_DESCRIPTION_DELETE("Delete a transaction entry from the list of transactions."),
+    COMMAND_DESCRIPTION_EDIT("Edit a transaction entry from the list of transactions."),
+    COMMAND_DESCRIPTION_FIND("Find a specific or multiple transactions based on any keywords that have been "
+            + "specified."),
+    COMMAND_DESCRIPTION_HELP("Display basic or detailed help information explaining the commands available in the "
+            + "application."),
+    COMMAND_DESCRIPTION_LIST("List all or some transactions based on selection. If tag filters are used, the "
+            + "transactions retrieved from the records must match all the filter tags that have been specified in "
+            + "order to be recognized as a valid record. The m/MONTH and y/YEAR tags should not be used together "
+            + "with p/PERIOD and n/NUMBER tags."),
+    COMMAND_DESCRIPTION_PURGE("Delete all transaction entries from the list of transactions."),
+    COMMAND_DESCRIPTION_STATS("View financial insights such as categorical savings and periodic expenditure based on "
+            + "the transaction entries in the application. The m/MONTH and y/YEAR tags should not be used together "
+            + "with p/PERIOD and n/NUMBER tags."),
+
+    // The guiding information for the usage of command
+    COMMAND_USAGE_ADD("Usage: add t/TYPE c/CATEGORY a/AMOUNT d/DATE i/DESCRIPTION"),
+    COMMAND_USAGE_BUDGET("Usage: budget b/BUDGET"),
+    COMMAND_USAGE_BYE("Usage: bye"),
+    COMMAND_USAGE_DELETE("Usage: delete e/ENTRY"),
+    COMMAND_USAGE_EDIT("Usage: edit e/ENTRY [t/TYPE] [c/CATEGORY] [a/AMOUNT] [d/DATE] [i/DESCRIPTION]"),
+    COMMAND_USAGE_FIND("Usage: find KEYWORDS"),
+    COMMAND_USAGE_HELP("Usage: help [o/detailed]"),
+    COMMAND_USAGE_LIST("Usage: list [t/TYPE] [c/CATEGORY] [d/DATE] [m/MONTH] [y/YEAR] [p/PERIOD] [n/NUMBER]"),
+    COMMAND_USAGE_PURGE("Usage: purge"),
+    COMMAND_USAGE_STATS("Usage: stats s/STATS_TYPE [m/MONTH] [y/YEAR] [p/PERIOD] [n/NUMBER]"),
+
+    // The formatting information for the parameters used by the command
+    COMMAND_PARAMETERS_DETAILED("- detailed: A detailed version of the guide."),
+    COMMAND_PARAMETERS_TYPE("- TYPE: The type of transaction. It should either be \"expense\" or \"income\"."),
+    COMMAND_PARAMETERS_CATEGORY("- CATEGORY: A category for the transaction. It is a one-word parameter "
+            + "flexibly defined by the user. No numeral, symbol or spacing is allowed."),
+    COMMAND_PARAMETERS_AMOUNT("- AMOUNT: The amount for the transaction. It is a positive whole number ranging "
+            + "from 1 to 10000000. No alphabet, symbol or spacing is allowed."),
+    COMMAND_PARAMETERS_DATE("- DATE: The date when the transaction took place on. It must be in ddMMyyyy "
+            + "format, e.g. 29102022."),
+    COMMAND_PARAMETERS_DESCRIPTION("- DESCRIPTION: More information regarding the transaction. It is a one-word"
+            + " parameter defined by the user without any spacing."),
+    COMMAND_PARAMETERS_ENTRY("- ENTRY: A list entry value for the transaction. It is a positive whole number "
+            + "ranging from 1 to 1000000."),
+    COMMAND_PARAMETERS_KEYWORDS("- KEYWORDS: A string that represents a single or a group of words used to find "
+            + "matching transactions. Spacing is allowed."),
+    COMMAND_PARAMETERS_BUDGET("- BUDGET: An estimate of income or expenditure for a set period of time. It is a "
+            + "positive whole number that is from 1 to 10^13 (Ten Trillion). No alphabet, symbol or spacing is "
+            + "allowed."),
+    COMMAND_PARAMETERS_STATS_TYPE("- STATS_TYPE: The type of statistics. It can be \"categorical_savings\", "
+            + "\"monthly_expenditure\", or \"time_insights\"."),
+    COMMAND_PARAMETERS_YEAR("- YEAR: The year which the transaction falls on. It must be in yyyy format and "
+            + "only year 1000 and onwards are accepted."),
+    COMMAND_PARAMETERS_MONTH("- MONTH: The month which the transaction falls on. It is in numerical form, i.e. "
+            + "from 1 to 12, where 1 represents January. This parameter must be used together with the YEAR "
+            + "parameter."),
+    COMMAND_PARAMETERS_PERIOD("- PERIOD: The period which the transaction falls on. It should either be weeks or "
+            + "months. This parameter must be used together with the NUMBER parameter."),
+    COMMAND_PARAMETERS_NUMBER("- NUMBER: The last N number of weeks or months. It is a positive whole number that "
+            + "is from 1 to 100. This parameter must be used together with the PERIOD parameter.");
+
+    //@@author chydarren
+    public final String message;
+
+    /**
+     * Instantiates a new information message when user initialises a new instance of this enum.
+     *
+     * @param message A string containing the message.
+     */
+    HelpMessages(String message) {
+        this.message = message;
+    }
+
+    /**
+     * Gets the information message as a string.
+     *
+     * @return A string containing the message.
+     */
+    public String toString() {
+        return message;
+    }
+}

--- a/src/main/java/seedu/duke/common/HelpMessages.java
+++ b/src/main/java/seedu/duke/common/HelpMessages.java
@@ -19,7 +19,8 @@ public enum HelpMessages {
             + "transactions retrieved from the records must match all the filter tags that have been specified in "
             + "order to be recognized as a valid record. The m/MONTH and y/YEAR tags should not be used together "
             + "with p/PERIOD and n/NUMBER tags."),
-    COMMAND_DESCRIPTION_PURGE("Delete all transaction entries from the list of transactions. User must enter 'Y' to confirm the purge."),
+    COMMAND_DESCRIPTION_PURGE("Delete all transaction entries from the list of transactions. User must enter 'Y' "
+            + "to confirm the purge."),
     COMMAND_DESCRIPTION_STATS("View financial insights such as categorical savings and periodic expenditure based on "
             + "the transaction entries in the application. The m/MONTH and y/YEAR tags should not be used together "
             + "with p/PERIOD and n/NUMBER tags."),

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -19,124 +19,122 @@ ____________________________________________________________
 ____________________________________________________________
 Gotcha! Here are the commands that you may use:
 Command Word: HELP
-To display a list of available commands with their respective expected parameters.
-Type "help o/detailed" for a detailed version of all parameters used.
+Display basic or detailed help information explaining the commands available in the application.
 Usage: help [o/detailed]
 
 Command Word: BUDGET
-To set the amount of monthly budget.
+Set the amount for monthly budget, with a value from 1 to 10^13 (Ten Trillion).
 Usage: budget b/BUDGET
 
 Command Word: ADD
-To add a new transaction entry, which could be either an "income" or an "expense" into the transaction list.
+Add a new transaction entry, which could be either an "expense" or "income" into the transactions list.
 Usage: add t/TYPE c/CATEGORY a/AMOUNT d/DATE i/DESCRIPTION
 
 Command Word: LIST
-To list all or some transactions based on selection. Tags will be joined in the filter based on the 'AND' operation.
+List all or some transactions based on selection. If tag filters are used, the transactions retrieved from the records must match all the filter tags that have been specified in order to be recognized as a valid record. The m/MONTH and y/YEAR tags should not be used together with p/PERIOD and n/NUMBER tags.
 Usage: list [t/TYPE] [c/CATEGORY] [d/DATE] [m/MONTH] [y/YEAR] [p/PERIOD] [n/NUMBER]
 
 Command Word: FIND
-To find specific transaction(s) based on any keywords inputted by the user.
+Find a specific or multiple transactions based on any keywords that have been specified.
 Usage: find KEYWORDS
 
 Command Word: STATS
-To get statistics of the transactions such as the total savings for each category, summary of expenditure over a time period.
+View financial insights such as categorical savings and periodic expenditure based on the transaction entries in the application. The m/MONTH and y/YEAR tags should not be used together with p/PERIOD and n/NUMBER tags.
 Usage: stats s/STATS_TYPE [m/MONTH] [y/YEAR] [p/PERIOD] [n/NUMBER]
 
 Command Word: EDIT
-To edit a specific entry in the list of transactions.
+Edit a transaction entry from the list of transactions.
 Usage: edit e/ENTRY [t/TYPE] [c/CATEGORY] [a/AMOUNT] [d/DATE] [i/DESCRIPTION]
 
 Command Word: DELETE
-To delete a specific entry in the list of transactions.
+Delete a transaction entry from the list of transactions.
 Usage: delete e/ENTRY
 
 Command Word: PURGE
-To purge a all entries in the list of transactions.
+Delete all transaction entries from the list of transactions.
 Usage: purge
 
 Command Word: BYE
-To exit the application.
+Exit the application.
 Usage: bye
 
 ____________________________________________________________
 ____________________________________________________________
 Gotcha! Here are the commands that you may use:
 Command Word: HELP
-To display a list of available commands with their respective expected parameters.
-Type "help o/detailed" for a detailed version of all parameters used.
+Display basic or detailed help information explaining the commands available in the application.
 Usage: help [o/detailed]
 Parameters information:
-(Optional) o/detailed - Detailed version of guide.
+- detailed: A detailed version of the guide.
 
 Command Word: BUDGET
-To set the amount of monthly budget.
+Set the amount for monthly budget, with a value from 1 to 10^13 (Ten Trillion).
 Usage: budget b/BUDGET
-Parameters information: 
-BUDGET - Amount of monthly budget set.
+Parameters information:
+- BUDGET: An estimate of income or expenditure for a set period of time. It is a positive whole number that is from 1 to 10^13 (Ten Trillion). No alphabet, symbol or spacing is allowed.
 
 Command Word: ADD
-To add a new transaction entry, which could be either an "income" or an "expense" into the transaction list.
+Add a new transaction entry, which could be either an "expense" or "income" into the transactions list.
 Usage: add t/TYPE c/CATEGORY a/AMOUNT d/DATE i/DESCRIPTION
 Parameters information:
-TYPE: The type of transaction. Only "income" or "expense" is accepted.
-CATEGORY: A category for the transaction. Only string containing alphabets is accepted.
-AMOUNT: Value of the transaction in numerical form. Only integer within 0 and 10000000 is accepted.
-DATE: Date of the transaction. The format must be in "yyyyMMdd".
-DESCRIPTION: More information regarding the transaction, written without any space.
+- TYPE: The type of transaction. It should either be "expense" or "income".
+- CATEGORY: A category for the transaction. It is a one-word parameter flexibly defined by the user. No numeral, symbol or spacing is allowed.
+- AMOUNT: The amount for the transaction. It is a positive whole number ranging from 1 to 10000000. No alphabet, symbol or spacing is allowed.
+- DESCRIPTION: More information regarding the transaction. It is a one-word parameter defined by the user without any spacing.
 
 Command Word: LIST
-To list all or some transactions based on selection. Tags will be joined in the filter based on the 'AND' operation.
+List all or some transactions based on selection. If tag filters are used, the transactions retrieved from the records must match all the filter tags that have been specified in order to be recognized as a valid record. The m/MONTH and y/YEAR tags should not be used together with p/PERIOD and n/NUMBER tags.
 Usage: list [t/TYPE] [c/CATEGORY] [d/DATE] [m/MONTH] [y/YEAR] [p/PERIOD] [n/NUMBER]
 Parameters information:
-(Optional) TYPE - The type of transaction. Only "income" or "expense" is accepted.
-(Optional) CATEGORY: A category for the transaction. Only string containing alphabets is accepted.
-(Optional) DATE: Date of the transaction. The format must be in "yyyyMMdd".
-(Optional) MONTH: Month of the transaction. Only integers within 1 to 12 are accepted. Note that month must be accompanied by a year. This tag cannot be used together with [p/PERIOD] or [n/NUMBER] tags.
-(Optional) YEAR: Year of the transaction. Only integers from 1000 onwards are accepted. This tag cannot be used together with [p/PERIOD] or [n/NUMBER] tags.
-(Optional) PERIOD: Period of the transaction. Only "weeks" or "months" is accepted. Note that period must be accompanied by a number to backdate from. This tag cannot be used together with [m/MONTH] or [y/YEAR] tags.
-(Optional) NUMBER: Last number of weeks or months. Only positive integers are accepted. Note that number must be accompanied by a period that represents weeks or months. This tag cannot be used together with [m/MONTH] or [y/YEAR] tags.
+- TYPE: The type of transaction. It should either be "expense" or "income".
+- CATEGORY: A category for the transaction. It is a one-word parameter flexibly defined by the user. No numeral, symbol or spacing is allowed.
+- DATE: The date when the transaction took place on. It must be in ddMMyyyy format, e.g. 29102022.
+- MONTH: The month which the transaction falls on. It is in numerical form, i.e. from 1 to 12, where 1 represents January. This parameter must be used together with the YEAR parameter.
+- YEAR: The year which the transaction falls on. It must be in yyyy format and only year 1000 and onwards are accepted.
+- PERIOD: The period which the transaction falls on. It should either be weeks or months. This parameter must be used together with the NUMBER parameter.
+- NUMBER: The last N number of weeks or months. It is a positive whole number that is from 1 to 100. This parameter must be used together with the PERIOD parameter.
 
 Command Word: FIND
-To find specific transaction(s) based on any keywords inputted by the user.
+Find a specific or multiple transactions based on any keywords that have been specified.
 Usage: find KEYWORDS
 Parameters information:
-KEYWORDS: Any partial or full keyword(s) that matches the details of the transaction, such as type, category, amount, date or description.
+- KEYWORDS: A string that represents a single or a group of words used to find matching transactions. Spacing is allowed.
 
 Command Word: STATS
-To get statistics of the transactions such as the total savings for each category, summary of expenditure over a time period.
+View financial insights such as categorical savings and periodic expenditure based on the transaction entries in the application. The m/MONTH and y/YEAR tags should not be used together with p/PERIOD and n/NUMBER tags.
 Usage: stats s/STATS_TYPE [m/MONTH] [y/YEAR] [p/PERIOD] [n/NUMBER]
 Parameters information:
-STATISTICS_TYPE: The type of statistics to be generated. Only "categorical_savings", "monthly_expenditure" or "time_insights" is accepted.
-(Optional) MONTH: Month of the transaction. Only integers within 1 to 12 are accepted. Note that month must be accompanied by a year. This tag cannot be used together with [p/PERIOD] or [n/NUMBER] tags.
-(Optional) YEAR: Year of the transaction. Only integers from 1000 onwards are accepted.This tag cannot be used together with [p/PERIOD] or [n/NUMBER] tags.
-(Optional) PERIOD: Period of the transaction. Only "weeks" or "months" is accepted. Note that period must be accompanied by a number to backdate from. This tag cannot be used together with [m/MONTH] or [y/YEAR] tags.
-(Optional) NUMBER: Last number of weeks or months. Only positive integers are accepted. Note thatnumber must be accompanied by a period that represents weeks or months. This tag cannot be used together with [m/MONTH] or [y/YEAR] tags.
+- STATS_TYPE: The type of statistics. It can be "categorical_savings", "monthly_expenditure", or "time_insights".
+- MONTH: The month which the transaction falls on. It is in numerical form, i.e. from 1 to 12, where 1 represents January. This parameter must be used together with the YEAR parameter.
+- YEAR: The year which the transaction falls on. It must be in yyyy format and only year 1000 and onwards are accepted.
+- PERIOD: The period which the transaction falls on. It should either be weeks or months. This parameter must be used together with the NUMBER parameter.
+- NUMBER: The last N number of weeks or months. It is a positive whole number that is from 1 to 100. This parameter must be used together with the PERIOD parameter.
 
 Command Word: EDIT
-To edit a specific entry in the list of transactions.
+Edit a transaction entry from the list of transactions.
 Usage: edit e/ENTRY [t/TYPE] [c/CATEGORY] [a/AMOUNT] [d/DATE] [i/DESCRIPTION]
 Parameters information:
-ENTRY: The entry number of the transaction. Type "list" to list all the entry numbers of transaction.
-(Optional) TYPE: The type of transaction. Only "income" or "expense" is accepted.
-(Optional) CATEGORY: A category for the transaction. Only string containing alphabets is accepted.
-(Optional) AMOUNT: Value of the transaction in numerical form. Only integer within 0 and 10000000 is accepted.
-(Optional) DATE: Date of the transaction. The format must be in "yyyyMMdd".
-(Optional) DESCRIPTION: More information regarding the transaction, written without any space.
+- ENTRY: A list entry value for the transaction. It is a positive whole number ranging from 1 to 1000000.
+- TYPE: The type of transaction. It should either be "expense" or "income".
+- CATEGORY: A category for the transaction. It is a one-word parameter flexibly defined by the user. No numeral, symbol or spacing is allowed.
+- AMOUNT: The amount for the transaction. It is a positive whole number ranging from 1 to 10000000. No alphabet, symbol or spacing is allowed.
+- AMOUNT: The amount for the transaction. It is a positive whole number ranging from 1 to 10000000. No alphabet, symbol or spacing is allowed.
+- DATE: The date when the transaction took place on. It must be in ddMMyyyy format, e.g. 29102022.
+- DESCRIPTION: More information regarding the transaction. It is a one-word parameter defined by the user without any spacing.
 
 Command Word: DELETE
-To delete a specific entry in the list of transactions.
+Delete a transaction entry from the list of transactions.
 Usage: delete e/ENTRY
 Parameters information:
-ENTRY: The entry number of the transaction. Type "list" to list all the entry numbers of transaction.
+- ENTRY: A list entry value for the transaction. It is a positive whole number ranging from 1 to 1000000.
 
 Command Word: PURGE
-To purge a all entries in the list of transactions.
+Delete all transaction entries from the list of transactions.
 Usage: purge
 Parameters information:  -NIL-
 
 Command Word: BYE
-To exit the application.
+Exit the application.
 Usage: bye
 Parameters information: -NIL-
 

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -51,7 +51,7 @@ Delete a transaction entry from the list of transactions.
 Usage: delete e/ENTRY
 
 Command Word: PURGE
-Delete all transaction entries from the list of transactions.
+Delete all transaction entries from the list of transactions. User must enter 'Y' to confirm the purge.
 Usage: purge
 
 Command Word: BYE
@@ -129,7 +129,7 @@ Parameters information:
 - ENTRY: A list entry value for the transaction. It is a positive whole number ranging from 1 to 1000000.
 
 Command Word: PURGE
-Delete all transaction entries from the list of transactions.
+Delete all transaction entries from the list of transactions. User must enter 'Y' to confirm the purge.
 Usage: purge
 Parameters information:  -NIL-
 


### PR DESCRIPTION
This pull request seeks to move all the help information for command description, usage and information of parameters to a common Help Messages Enum class so that all the help information can be synchronized across all command classes, and easier for us to update against the UG. Thanks to @wcwy for suggesting to move these.