### PR TITLE
Budget improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,6 @@ src/main/resources/docs/
 bin/
 
 
-data/duke.txt
+!/data/duke.txt
 /text-ui-test/ACTUAL.txt
 text-ui-test/EXPECTED-UNIX.TXT

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ src/main/resources/docs/
 *.iml
 bin/
 
-
-!/data/duke.txt
 /text-ui-test/ACTUAL.txt
 text-ui-test/EXPECTED-UNIX.TXT
+data/duke.txt

--- a/src/main/java/seedu/duke/Ui.java
+++ b/src/main/java/seedu/duke/Ui.java
@@ -110,12 +110,38 @@ public class Ui {
     /**
      * Prepares the time insights list messages to be displayed to the user.
      *
-     * @param list    A string containing the formatted time insights list.
-     * @param message A message that complements with the time insights list.
+     * @param list           A string containing the formatted time insights list.
+     * @param message        A message that complements with the time insights list.
+     * @param incomeMessage  A string containing the formatted income amount.
+     * @param expenseMessage A string containing the formatted expense amount.
+     * @param savingsMessage A string containing the formatted savings amount.
      */
     public static void showTimeInsightsList(String list, String message, String incomeMessage,
-                                            String expenseMessage, String savingsMessage) {
+            String expenseMessage, String savingsMessage) {
         printMessages(message, list, incomeMessage, expenseMessage, savingsMessage);
+    }
+
+    //@@author wcwy
+
+    /**
+     * Prepares the time insights list messages to be displayed to the user for a specific month.
+     *
+     * <p>This is an overload method to specifically catered for display of budget-related message
+     * when the user chose to view the statistic for a specific month. For example,
+     * command 'stats s/time_insights m/2 y/2022' will utilise this function to display also the budget messages to the
+     * user.
+     *
+     * @param list           A string containing the formatted time insights list.
+     * @param message        A message that complements with the time insights list.
+     * @param incomeMessage  A string containing the formatted income amount.
+     * @param expenseMessage A string containing the formatted expense amount.
+     * @param savingsMessage A string containing the formatted savings amount.
+     * @param budgetMessage  A string containing the formatted budget amount.
+     * @param budgetAdvice   A string containing the formatted budget advice.
+     */
+    public static void showTimeInsightsList(String list, String message, String incomeMessage,
+            String expenseMessage, String savingsMessage, String budgetMessage, String budgetAdvice) {
+        printMessages(message, list, incomeMessage, expenseMessage, savingsMessage, budgetMessage, budgetAdvice);
     }
 
     //@@author chydarren

--- a/src/main/java/seedu/duke/command/ListAndStatsCommand.java
+++ b/src/main/java/seedu/duke/command/ListAndStatsCommand.java
@@ -19,9 +19,9 @@ import java.util.logging.Logger;
 public abstract class ListAndStatsCommand extends Command {
     //@@author chydarren
     private static final int UNDEFINED_PARAMETER = -1;
-    private static final int CONTAIN_BOTH = 1;
-    private static final int CONTAIN_EITHER = 2;
-    private static final int CONTAIN_EITHER_INVALID = 3;
+    public static final int CONTAIN_BOTH = 1;
+    public static final int CONTAIN_EITHER = 2;
+    public static final int CONTAIN_EITHER_INVALID = 3;
     private static final int FALSE = 0;
     private static final String WEEKS = "weeks";
     private static final String MONTHS = "months";

--- a/src/main/java/seedu/duke/command/StatsCommand.java
+++ b/src/main/java/seedu/duke/command/StatsCommand.java
@@ -4,6 +4,7 @@ package seedu.duke.command;
 
 import seedu.duke.Storage;
 import seedu.duke.Ui;
+import seedu.duke.data.Budget;
 import seedu.duke.data.TransactionList;
 import seedu.duke.data.transaction.Transaction;
 import seedu.duke.exception.GlobalMissingTagException;
@@ -32,6 +33,7 @@ import static seedu.duke.common.InfoMessages.DOLLAR_SIGN;
 import static seedu.duke.common.InfoMessages.INFO_EXPENSE;
 import static seedu.duke.common.InfoMessages.INFO_INCOME;
 import static seedu.duke.common.InfoMessages.INFO_SAVINGS;
+import static seedu.duke.common.InfoMessages.INFO_BUDGET;
 import static seedu.duke.common.InfoMessages.INFO_STATS_CATEGORY;
 import static seedu.duke.common.InfoMessages.INFO_STATS_EMPTY;
 import static seedu.duke.common.InfoMessages.INFO_STATS_EXPENDITURE_HEADER;
@@ -87,11 +89,11 @@ public class StatsCommand extends ListAndStatsCommand {
     @Override
     public String[] getOptionalTags() {
         String[] optionalTags = new String[]{
-            COMMAND_TAG_GLOBAL_MONTH,
-            COMMAND_TAG_GLOBAL_YEAR,
-            COMMAND_TAG_GLOBAL_NUMBER,
-            COMMAND_TAG_GLOBAL_PERIOD,
-        };
+                COMMAND_TAG_GLOBAL_MONTH,
+                COMMAND_TAG_GLOBAL_YEAR,
+                COMMAND_TAG_GLOBAL_NUMBER,
+                COMMAND_TAG_GLOBAL_PERIOD,
+                };
         return optionalTags;
     }
 
@@ -130,7 +132,7 @@ public class StatsCommand extends ListAndStatsCommand {
     /**
      * Lists the statistics depending on the type of statistics requested.
      *
-     * @param transactions  An instance of the TransactionList class.
+     * @param transactions An instance of the TransactionList class.
      * @throws MoolahException If the type of statistics is not recognised.
      */
     public void listStatsByStatsType(TransactionList transactions) throws MoolahException {
@@ -213,10 +215,39 @@ public class StatsCommand extends ListAndStatsCommand {
         String expensesMessage = String.format("%s%s%s", INFO_EXPENSE, COLON_SPACE, DOLLAR_SIGN) + amounts.get(1);
         String savingsMessage = String.format("%s%s%s", INFO_SAVINGS, COLON_SPACE, DOLLAR_SIGN) + amounts.get(2);
 
+        printTimeInsightsStatistics(timeInsightsList, amounts, incomeMessage, expensesMessage, savingsMessage);
+
         assert !timeInsightsList.isEmpty();
         statsLogger.log(Level.INFO, "Time insights list has info available for the specified time period.");
-        Ui.showTimeInsightsList(timeInsightsList, INFO_STATS_TIME_INSIGHTS.toString(), incomeMessage, expensesMessage,
-                savingsMessage);
+
+    }
+
+    /**
+     * Prints the statistics for time insights based on the parameters chosen.
+     *
+     * @param timeInsightsList A string message containing the categorical list statistics for the time chosen.
+     * @param amounts          An arraylist holding the statistics of the transaction for the time chosen.
+     * @param incomeMessage    A string containing the formatted income.
+     * @param expensesMessage  A string containing the formatted expense.
+     * @param savingsMessage   A string containing the formatted savings.
+     */
+    private static void printTimeInsightsStatistics(String timeInsightsList, ArrayList<String> amounts,
+            String incomeMessage, String expensesMessage, String savingsMessage) {
+
+        if (containMonthYear() == CONTAIN_BOTH) {
+            // Information on budget is only displayed when displaying a specific month's time insights
+            String budgetMessage = String.format("%s%s%s", INFO_BUDGET, COLON_SPACE, DOLLAR_SIGN) + Budget.getBudget();
+
+            long budgetLeft = Budget.calculateBudgetLeft(Long.parseLong(amounts.get(1)));
+            String budgetAdvice = Budget.generateBudgetAdvice(budgetLeft, Budget.hasExceededBudget(budgetLeft));
+
+            Ui.showTimeInsightsList(timeInsightsList, INFO_STATS_TIME_INSIGHTS.toString(), incomeMessage,
+                    expensesMessage, savingsMessage, budgetMessage, budgetAdvice);
+        } else {
+            //@@author paullowse
+            Ui.showTimeInsightsList(timeInsightsList, INFO_STATS_TIME_INSIGHTS.toString(), incomeMessage,
+                    expensesMessage, savingsMessage);
+        }
     }
 
     /**

--- a/src/main/java/seedu/duke/command/StatsCommand.java
+++ b/src/main/java/seedu/duke/command/StatsCommand.java
@@ -89,11 +89,11 @@ public class StatsCommand extends ListAndStatsCommand {
     @Override
     public String[] getOptionalTags() {
         String[] optionalTags = new String[]{
-                COMMAND_TAG_GLOBAL_MONTH,
-                COMMAND_TAG_GLOBAL_YEAR,
-                COMMAND_TAG_GLOBAL_NUMBER,
-                COMMAND_TAG_GLOBAL_PERIOD,
-                };
+            COMMAND_TAG_GLOBAL_MONTH,
+            COMMAND_TAG_GLOBAL_YEAR,
+            COMMAND_TAG_GLOBAL_NUMBER,
+            COMMAND_TAG_GLOBAL_PERIOD,
+            };
         return optionalTags;
     }
 

--- a/src/main/java/seedu/duke/common/ErrorMessages.java
+++ b/src/main/java/seedu/duke/common/ErrorMessages.java
@@ -44,7 +44,7 @@ public enum ErrorMessages {
     ERROR_MAXIMUM_TRANSACTION_COUNT_REACHED("Unable to add transaction. "
             + "The maximum allowed transaction size (1000000) has been reached."),
 
-    ERROR_INVALID_BUDGET("Invalid budget amount! (Note: Budget must be a positive integer of valid range)"
+    ERROR_INVALID_BUDGET("Invalid budget amount! (Note: Budget must be a positive whole number of valid range)"
             + " Please enter <help> for the command guide."),
     ERROR_DUPLICATE_BUDGET("Provided budget is the same as the originally set value.");
 

--- a/src/main/java/seedu/duke/common/InfoMessages.java
+++ b/src/main/java/seedu/duke/common/InfoMessages.java
@@ -44,7 +44,7 @@ public enum InfoMessages {
     INFO_PURGE_WARNING("Are you sure you want to proceed with this command? Please enter 'Y' to confirm."),
     INFO_BUDGET_SET_SUCCESSFUL("You have successfully updated the budget."),
     INFO_CURRENT_BUDGET("Monthly budget set as: $"),
-    INFO_REMAINING_BUDGET("Budget remained for "),
+    INFO_REMAINING_BUDGET("Remaining budget for "),
     INFO_EXCEEDING_BUDGET("Budget exceeded for "),
     INFO_BUDGET_EXCEEDED_TIPS("Consider spending less!"),
     INFO_BUDGET_NOT_EXCEEDED_TIPS("Keep it up!"),

--- a/src/main/java/seedu/duke/common/InfoMessages.java
+++ b/src/main/java/seedu/duke/common/InfoMessages.java
@@ -13,6 +13,7 @@ public enum InfoMessages {
     INFO_INCOME("Income"),
     INFO_EXPENSE("Expense"),
     INFO_SAVINGS("Savings"),
+    INFO_BUDGET("Budget"),
     INFO_DIVIDER("____________________________________________________________"),
     INFO_ADD_EXPENSE("I have added the following Expense transaction:"),
     INFO_ADD_INCOME("I have added the following Income transaction:"),
@@ -33,11 +34,13 @@ public enum InfoMessages {
     INFO_STATS_HABIT_VERY_HIGH_SAVINGS("Excellent! You saved quite a lot this month."),
     INFO_STATS_HABIT_HIGH_SAVINGS("Wow, keep up the good work. You saved at least two-third of your income."),
     INFO_STATS_HABIT_MEDIUM_SAVINGS("Good effort, you saved at least half of your income."),
-    INFO_STATS_HABIT_LOW_SAVINGS("Hmm, you spent quite a sum. Try saving more in future."),
-    INFO_STATS_HABIT_VERY_LOW_SAVINGS("Oops, you spent too much. Do manage your expenses within your constraints."),
-    INFO_STATS_TIME_INSIGHTS("Here are the categorical savings and monthly time insights for"),
-    INFO_STATS_CATEGORIES_HEADER("-----CATEGORIES-----"),
-    INFO_STATS_EXPENDITURE_HEADER("-----EXPENDITURE-----"),
+    INFO_STATS_HABIT_LOW_SAVINGS("Hmm, you are spending more than 50% of what you earned. "
+            + "Do strike a balance between what you earn and what you spend for better savings!"),
+    INFO_STATS_HABIT_VERY_LOW_SAVINGS("You spent way more than what you have earned for the current month. "
+            + "Please spend wisely based on your income"),
+    INFO_STATS_TIME_INSIGHTS("Here are the categorical savings and expenditure summary for"),
+    INFO_STATS_CATEGORIES_HEADER("-----Categorical Savings-----"),
+    INFO_STATS_EXPENDITURE_HEADER("-----Expenditure Summary-----"),
     INFO_PURGE("All your transactions have been purged."),
     INFO_PURGE_ABORT("Purging has been aborted. All transactions records are retained."),
     INFO_PURGE_EMPTY("The command is aborted as the transactions list is empty."),
@@ -49,7 +52,12 @@ public enum InfoMessages {
     INFO_BUDGET_EXCEEDED_TIPS("Consider spending less!"),
     INFO_BUDGET_NOT_EXCEEDED_TIPS("Keep it up!"),
     INFO_BUDGET_EXCEEDED_REMINDER("REMINDER: You have already exceeded the budget set for current month!"),
-    INFO_BUDGET_NOT_EXCEEDED_REMINDER("REMINDER: Continue to stay within your budget for this month! Good fortune!");
+    INFO_BUDGET_NOT_EXCEEDED_REMINDER("REMINDER: Continue to stay within your budget for this month! Good fortune!"),
+    INFO_SAVING_TIPS_AND_BUDGET_ADVICE_SEPARATOR("In terms of monthly budget, "),
+    INFO_BUDGET_EXCEEDED_ADVICE_HIGH("you have exceeded more than twice of your budget!"),
+    INFO_BUDGET_EXCEEDED_ADVICE_LOW("you have spent more than your budget planned!"),
+    INFO_BUDGET_NOT_EXCEEDED_ADVICE_HIGH("you are left with less than half of your budget for the month!"),
+    INFO_BUDGET_NOT_EXCEEDED_LOW("you have kept yourself well within the budget!");
 
     //@@author chydarren
     public final String message;

--- a/src/main/java/seedu/duke/data/Budget.java
+++ b/src/main/java/seedu/duke/data/Budget.java
@@ -16,6 +16,11 @@ import static seedu.duke.common.InfoMessages.DOLLAR_SIGN;
 import static seedu.duke.common.InfoMessages.COLON_SPACE;
 import static seedu.duke.common.InfoMessages.FULL_STOP_SPACE;
 import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
+import static seedu.duke.common.InfoMessages.INFO_SAVING_TIPS_AND_BUDGET_ADVICE_SEPARATOR;
+import static seedu.duke.common.InfoMessages.INFO_BUDGET_EXCEEDED_ADVICE_HIGH;
+import static seedu.duke.common.InfoMessages.INFO_BUDGET_EXCEEDED_ADVICE_LOW;
+import static seedu.duke.common.InfoMessages.INFO_BUDGET_NOT_EXCEEDED_ADVICE_HIGH;
+import static seedu.duke.common.InfoMessages.INFO_BUDGET_NOT_EXCEEDED_LOW;
 
 //@@author wcwy
 
@@ -96,7 +101,7 @@ public class Budget {
      * @param totalMonthlyExpense The long value representing the total sum of a monthly expense.
      * @return A long value representing the amount of budget left.
      */
-    private static long calculateBudgetLeft(long totalMonthlyExpense) {
+    public static long calculateBudgetLeft(long totalMonthlyExpense) {
         /*
             Since the maximum number of transaction is 1000000, maximum amount of expense is 10000000,
             and minimum is 1, the lowest possible budget left value is
@@ -123,7 +128,7 @@ public class Budget {
      * @param budgetLeft A long value indicating the difference of total monthly expense and monthly budget.
      * @return A boolean value indicating whether the budget has been exceeded for the month.
      */
-    private static boolean hasExceededBudget(long budgetLeft) {
+    public static boolean hasExceededBudget(long budgetLeft) {
         return budgetLeft < 0;
     }
 
@@ -150,6 +155,8 @@ public class Budget {
     /**
      * Retrieves a money managing tips based on whether budget has been exceeded.
      *
+     * <p>This method is used to provide a spending tips to the user on transaction list modification.
+     *
      * @param hasExceededBudget A boolean value indicating whether the budget has been exceeded for the month.
      * @return A string containing a money managing tips to the user.
      */
@@ -161,6 +168,14 @@ public class Budget {
         }
     }
 
+    /**
+     * Retrieves a money managing reminder based on whether budget has been exceeded.
+     *
+     * <p>This method is used to provide a reminder to the user on application starts.
+     *
+     * @param hasExceededBudget A boolean value indicating whether the budget has been exceeded for the month.
+     * @return A string containing a money managing reminder to the user.
+     */
     private static String generateBudgetReminder(boolean hasExceededBudget) {
         if (hasExceededBudget) {
             return INFO_BUDGET_EXCEEDED_REMINDER.toString();
@@ -168,6 +183,51 @@ public class Budget {
             return INFO_BUDGET_NOT_EXCEEDED_REMINDER.toString();
         }
 
+    }
+
+    /**
+     * Retrieves a money managing advices based on whether budget has been exceeded, and the proportion of the
+     * exceeding or remaining budget.
+     *
+     * <p>This method is used to provide advice to the user when viewing monthly statistics.
+     *
+     * @param budgetLeft        A long value indicating the difference of total monthly expense and monthly budget.
+     * @param hasExceededBudget A boolean value indicating whether the budget has been exceeded for the month.
+     * @return A string containing a money managing tips to the user.
+     */
+    public static String generateBudgetAdvice(long budgetLeft, boolean hasExceededBudget) {
+        // A string to separate the budget advice from saving tips for better logical flow
+        String message = INFO_SAVING_TIPS_AND_BUDGET_ADVICE_SEPARATOR.toString();
+
+        // Only used if budget has exceeded
+        boolean hasExceededBudgetMoreThanTwice = abs(budgetLeft) > budget * 2;
+
+        // Only used if budget has not exceeded
+        boolean hasLeftLessThanHalfOfBudget = budgetLeft * 2 < budget;
+
+        /*
+           A budget is said to have highly exceeded when the budget is exceeded more than twice of itself.
+           Otherwise, a budget is not highly exceeded.
+
+           A budget is said to have highly spent but within budget when the budget left is less than half of budget.
+           Otherwise, a budget is lowly spent and within budget.
+         */
+        if (hasExceededBudget && hasExceededBudgetMoreThanTwice) {
+            message += INFO_BUDGET_EXCEEDED_ADVICE_HIGH;
+        }
+
+        if (hasExceededBudget && !hasExceededBudgetMoreThanTwice) {
+            message += INFO_BUDGET_EXCEEDED_ADVICE_LOW;
+        }
+
+        if (!hasExceededBudget && hasLeftLessThanHalfOfBudget) {
+            message += INFO_BUDGET_NOT_EXCEEDED_ADVICE_HIGH;
+        }
+
+        if (!hasExceededBudget && !hasLeftLessThanHalfOfBudget) {
+            message += INFO_BUDGET_NOT_EXCEEDED_LOW;
+        }
+        return message;
     }
 
 

--- a/src/main/java/seedu/duke/data/TransactionList.java
+++ b/src/main/java/seedu/duke/data/TransactionList.java
@@ -17,18 +17,7 @@ import static seedu.duke.common.Constants.MAX_AMOUNT_VALUE;
 import static seedu.duke.common.Constants.MIN_AMOUNT_VALUE;
 import static seedu.duke.common.Constants.MAX_TRANSACTIONS_COUNT;
 import static seedu.duke.common.DateFormats.DATE_MONTH_PATTERN;
-import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
-import static seedu.duke.common.InfoMessages.DOLLAR_SIGN;
-import static seedu.duke.common.InfoMessages.COLON_SPACE;
-import static seedu.duke.common.InfoMessages.INFO_INCOME;
-import static seedu.duke.common.InfoMessages.INFO_EXPENSE;
-import static seedu.duke.common.InfoMessages.INFO_SAVINGS;
-import static seedu.duke.common.InfoMessages.INFO_STATS_CATEGORIES_HEADER;
-import static seedu.duke.common.InfoMessages.INFO_STATS_HABIT_VERY_LOW_SAVINGS;
-import static seedu.duke.common.InfoMessages.INFO_STATS_HABIT_LOW_SAVINGS;
-import static seedu.duke.common.InfoMessages.INFO_STATS_HABIT_MEDIUM_SAVINGS;
-import static seedu.duke.common.InfoMessages.INFO_STATS_HABIT_HIGH_SAVINGS;
-import static seedu.duke.common.InfoMessages.INFO_STATS_HABIT_VERY_HIGH_SAVINGS;
+import static seedu.duke.common.InfoMessages.*;
 
 
 //@@author chydarren
@@ -371,8 +360,15 @@ public class TransactionList {
                     entry.getValue()[1], LINE_SEPARATOR);
             monthlyExpenditureList += String.format("%s%s%s%s%s", INFO_SAVINGS, COLON_SPACE, DOLLAR_SIGN,
                     entry.getValue()[2], LINE_SEPARATOR);
-            monthlyExpenditureList += String.format("%s%s%s%s", "Spending Habit: ",
-                    getSpendingHabitComment(entry.getValue()[2], entry.getValue()[0]), LINE_SEPARATOR, LINE_SEPARATOR);
+            monthlyExpenditureList += String.format("%s%s%s%s%s", INFO_BUDGET, COLON_SPACE, DOLLAR_SIGN,
+                    Budget.getBudget(), LINE_SEPARATOR);
+            monthlyExpenditureList += String.format("%s%s%s", "Spending Habit: ",
+                    getSpendingHabitComment(entry.getValue()[2], entry.getValue()[0]), LINE_SEPARATOR);
+
+            // Information on budget is only displayed when displaying a specific month's time insights
+            long budgetLeft = Budget.calculateBudgetLeft(entry.getValue()[1]);
+            String budgetAdvice = Budget.generateBudgetAdvice(budgetLeft, Budget.hasExceededBudget(budgetLeft));
+            monthlyExpenditureList += String.format("%s%s%s", budgetAdvice, LINE_SEPARATOR, LINE_SEPARATOR);
         }
 
         return monthlyExpenditureList;

--- a/src/main/java/seedu/duke/data/TransactionList.java
+++ b/src/main/java/seedu/duke/data/TransactionList.java
@@ -17,7 +17,19 @@ import static seedu.duke.common.Constants.MAX_AMOUNT_VALUE;
 import static seedu.duke.common.Constants.MIN_AMOUNT_VALUE;
 import static seedu.duke.common.Constants.MAX_TRANSACTIONS_COUNT;
 import static seedu.duke.common.DateFormats.DATE_MONTH_PATTERN;
-import static seedu.duke.common.InfoMessages.*;
+import static seedu.duke.common.InfoMessages.LINE_SEPARATOR;
+import static seedu.duke.common.InfoMessages.DOLLAR_SIGN;
+import static seedu.duke.common.InfoMessages.COLON_SPACE;
+import static seedu.duke.common.InfoMessages.INFO_INCOME;
+import static seedu.duke.common.InfoMessages.INFO_EXPENSE;
+import static seedu.duke.common.InfoMessages.INFO_SAVINGS;
+import static seedu.duke.common.InfoMessages.INFO_BUDGET;
+import static seedu.duke.common.InfoMessages.INFO_STATS_CATEGORIES_HEADER;
+import static seedu.duke.common.InfoMessages.INFO_STATS_HABIT_VERY_LOW_SAVINGS;
+import static seedu.duke.common.InfoMessages.INFO_STATS_HABIT_LOW_SAVINGS;
+import static seedu.duke.common.InfoMessages.INFO_STATS_HABIT_MEDIUM_SAVINGS;
+import static seedu.duke.common.InfoMessages.INFO_STATS_HABIT_HIGH_SAVINGS;
+import static seedu.duke.common.InfoMessages.INFO_STATS_HABIT_VERY_HIGH_SAVINGS;
 
 
 //@@author chydarren

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -12,7 +12,7 @@ ____________________________________________________________
 ____________________________________________________________
 ____________________________________________________________
 Hello! I'm Moo and I will help you to manage your finances.
-Budget remained for current month: $1000
+Remaining budget for current month: $1000
 REMINDER: Continue to stay within your budget for this month! Good fortune!
 Enter <help> if you need the list of commands.
 ____________________________________________________________
@@ -167,21 +167,21 @@ ____________________________________________________________
 Mandatory tag(s) missing, please enter <help> for the command guide.
 ____________________________________________________________
 ____________________________________________________________
-Invalid budget amount! (Note: Budget must be a positive integer of valid range) Please enter <help> for the command guide.
+Invalid budget amount! (Note: Budget must be a positive whole number of valid range) Please enter <help> for the command guide.
 ____________________________________________________________
 ____________________________________________________________
-Invalid budget amount! (Note: Budget must be a positive integer of valid range) Please enter <help> for the command guide.
+Invalid budget amount! (Note: Budget must be a positive whole number of valid range) Please enter <help> for the command guide.
 ____________________________________________________________
 ____________________________________________________________
-Invalid budget amount! (Note: Budget must be a positive integer of valid range) Please enter <help> for the command guide.
+Invalid budget amount! (Note: Budget must be a positive whole number of valid range) Please enter <help> for the command guide.
 ____________________________________________________________
 ____________________________________________________________
-Invalid budget amount! (Note: Budget must be a positive integer of valid range) Please enter <help> for the command guide.
+Invalid budget amount! (Note: Budget must be a positive whole number of valid range) Please enter <help> for the command guide.
 ____________________________________________________________
 ____________________________________________________________
 You have successfully updated the budget.
 Monthly budget set as: $10000
-Budget remained for current month: $10000
+Remaining budget for current month: $10000
 REMINDER: Continue to stay within your budget for this month! Good fortune!
 ____________________________________________________________
 ____________________________________________________________
@@ -214,7 +214,7 @@ ____________________________________________________________
 ____________________________________________________________
 I have added the following Expense transaction:
 [-][food] $20 on Sep 13 2022 | Description: NIL
-Budget remained for Sep 2022: $9980. Keep it up!
+Remaining budget for Sep 2022: $9980. Keep it up!
 ____________________________________________________________
 ____________________________________________________________
 Invalid amount! (Note: Amount must be positive integer, $10000000 or less only) Please enter <help> for the command guide.
@@ -228,12 +228,12 @@ ____________________________________________________________
 ____________________________________________________________
 I have added the following Income transaction:
 [+][salary] $2000 on Sep 30 2022 | Description: jan_salary
-Budget remained for Sep 2022: $9980. Keep it up!
+Remaining budget for Sep 2022: $9980. Keep it up!
 ____________________________________________________________
 ____________________________________________________________
 I have added the following Expense transaction:
 [-][transport] $1 on Oct 02 2022 | Description: bus_fare
-Budget remained for Oct 2022: $9999. Keep it up!
+Remaining budget for Oct 2022: $9999. Keep it up!
 ____________________________________________________________
 ____________________________________________________________
 Parameter behind tag(s) is found to be empty, please enter <help> for the command guide.
@@ -454,11 +454,11 @@ ____________________________________________________________
 ____________________________________________________________
 You have successfully updated the budget.
 Monthly budget set as: $10000000000000
-Budget remained for current month: $9999999989999
+Remaining budget for current month: $9999999989999
 REMINDER: Continue to stay within your budget for this month! Good fortune!
 ____________________________________________________________
 ____________________________________________________________
-Invalid budget amount! (Note: Budget must be a positive integer of valid range) Please enter <help> for the command guide.
+Invalid budget amount! (Note: Budget must be a positive whole number of valid range) Please enter <help> for the command guide.
 ____________________________________________________________
 ____________________________________________________________
 Mandatory tag(s) missing, please enter <help> for the command guide.
@@ -466,7 +466,7 @@ ____________________________________________________________
 ____________________________________________________________
 I have deleted the following transaction:
 [-][food] $20 on Sep 13 2022 | Description: NIL
-Budget remained for Sep 2022: $10000000000000. Keep it up!
+Remaining budget for Sep 2022: $10000000000000. Keep it up!
 ____________________________________________________________
 ____________________________________________________________
 Here are your transaction records:
@@ -485,12 +485,12 @@ ____________________________________________________________
 ____________________________________________________________
 I have deleted the following transaction:
 [+][bonus] $10000000 on Oct 03 2022 | Description: thank_you_boss
-Budget remained for Oct 2022: $9999999989999. Keep it up!
+Remaining budget for Oct 2022: $9999999989999. Keep it up!
 ____________________________________________________________
 ____________________________________________________________
 I have deleted the following transaction:
 [-][transport] $10000 on Oct 03 2022 | Description: bus_fare
-Budget remained for Oct 2022: $9999999999999. Keep it up!
+Remaining budget for Oct 2022: $9999999999999. Keep it up!
 ____________________________________________________________
 ____________________________________________________________
 Here are your transaction records:
@@ -546,7 +546,7 @@ ____________________________________________________________
 ____________________________________________________________
 I have added the following Expense transaction:
 [-][transport] $1 on Oct 02 2022 | Description: i/i/i/i/
-Budget remained for Oct 2022: $9999999999999. Keep it up!
+Remaining budget for Oct 2022: $9999999999999. Keep it up!
 ____________________________________________________________
 ____________________________________________________________
 Not supported tag(s) detected, please enter <help> for the command guide.

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -311,66 +311,72 @@ Here are your requested monthly statistics:
 Income: $2000
 Expense: $20
 Savings: $1980
+Budget: $10000
 Spending Habit: Excellent! You saved quite a lot this month.
+In terms of monthly budget, you have kept yourself well within the budget!
 
 [Oct 2022]
 Income: $0
 Expense: $10001
 Savings: $-10001
-Spending Habit: Oops, you spent too much. Do manage your expenses within your constraints.
+Budget: $10000
+Spending Habit: You spent way more than what you have earned for the current month. Please spend wisely based on your income
+In terms of monthly budget, you have spent more than your budget planned!
 
 
 ____________________________________________________________
 ____________________________________________________________
-Here are the categorical savings and monthly time insights for
+Here are the categorical savings and expenditure summary for
 Year: 2022
 
------CATEGORIES-----
+-----Categorical Savings-----
 [transport] $-10001
 [salary] $2000
 [food] $-20
 
------EXPENDITURE-----
+-----Expenditure Summary-----
 Income: $2000
 Expense: $10021
 Savings: $-8021
 ____________________________________________________________
 ____________________________________________________________
-Here are the categorical savings and monthly time insights for
+Here are the categorical savings and expenditure summary for
 Year: 2022, Month: 10
 
------CATEGORIES-----
+-----Categorical Savings-----
 [transport] $-10001
 
------EXPENDITURE-----
+-----Expenditure Summary-----
 Income: $0
 Expense: $10001
 Savings: $-10001
+Budget: $10000
+In terms of monthly budget, you have spent more than your budget planned!
 ____________________________________________________________
 ____________________________________________________________
 Month tag must be accompanied by a year tag, please enter <help> for the command guide.
 ____________________________________________________________
 ____________________________________________________________
-Here are the categorical savings and monthly time insights for
+Here are the categorical savings and expenditure summary for
 The past 3 weeks: 
 
------CATEGORIES-----
+-----Categorical Savings-----
 [transport] $-10000
 
------EXPENDITURE-----
+-----Expenditure Summary-----
 Income: $0
 Expense: $10000
 Savings: $-10000
 ____________________________________________________________
 ____________________________________________________________
-Here are the categorical savings and monthly time insights for
+Here are the categorical savings and expenditure summary for
 The past 4 months: 
 
------CATEGORIES-----
+-----Categorical Savings-----
 [salary] $2000
 [food] $-20
 
------EXPENDITURE-----
+-----Expenditure Summary-----
 Income: $2000
 Expense: $20
 Savings: $1980


### PR DESCRIPTION
This PR aims to improve the budget implementation with the following: 
1. Fix the grammar mistake in the error messaged identified in #160.
2. Implement viewing of budget in `stats` execution for monthly_expenditure and time_insights option (with month and year only). 
3. Implement budget advisory message in `stats` under same scenario as (2).

The budget advisory message in (3) will be displayed adaptively based on the ratio of the budget-expense difference to the monthly budget. 